### PR TITLE
Populated mob data for floors 1-50

### DIFF
--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -111,13 +111,7 @@
 # EO boss floor 10
 12240-Gancanagh:
   Threat: Caution
-  Aggro: Undefined
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
+  Aggro: Boss
 
 # EO floors 11-19
 12130-great Orthos morbol:
@@ -348,133 +342,131 @@
     - SleepUnknown
 
 # EO boss floor 30
-# 12242-Tiamat clone:
-#   Threat: Caution
-#   Aggro: Undefined
-#   Weakness:
+12242-Tiamat clone:
+  Threat: Caution
+  Aggro: Boss
 
-# # EO floors 31-39
-# 12149-mirrorknight:
-#   Threat: Caution
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12154-orthikalison:
-#   Threat: Easy
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12146-orthospider:
-#   Threat: Caution
-#   Aggro: Sound
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12145-orthobug:
-#   Threat: Easy
-#   Aggro: Proximity
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12153-Orthos shabti:
-#   Threat: Easy
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12157-Orthos lamia:
-#   Threat: Easy
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12147-orthopredator:
-#   Threat: Easy
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - SleepUnknown
-# 12155-orthonaga:
-#   Threat: Easy
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12150-orthotaur:
-#   Threat: Caution
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12148-Phantom orthoray:
-#   Threat: Dangerous
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12151-Orthos reptoid:
-#   Threat: Easy
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12152-orthochimera:
-#   Threat: Dangerous
-#   Aggro: Sight
-#   Weakness:
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
-# 12156-orthoempuse:
-#   Threat: Caution
-#   Aggro: Sight
-#   Weakness:
-#     - StunUnknown
-#     - HeavyUnknown
-#     - SlowUnknown
-#     - BindUnknown
-#     - SleepUnknown
+# EO floors 31-39
+12149-mirrorknight:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12154-orthikalison:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12146-orthospider:
+  Threat: Caution
+  Aggro: Sound
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12145-orthobug:
+  Threat: Easy
+  Aggro: Proximity
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12153-Orthos shabti:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12157-Orthos lamia:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12147-orthopredator:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - SleepUnknown
+12155-orthonaga:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12150-orthotaur:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12148-Phantom orthoray:
+  Threat: Dangerous
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12151-Orthos reptoid:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12152-orthochimera:
+  Threat: Dangerous
+  Aggro: Sight
+  Weakness:
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12156-orthoempuse:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
 
-# # EO boss floor 40
-# 12263-Twintania clone:
-#   Threat: Caution
-#   Aggro: Undefined
-#   Weakness:
+# EO boss floor 40
+12263-Twintania clone:
+  Threat: Caution
+  Aggro: Boss
 
 # EO floors 41-49
 # -bergthurs

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -294,11 +294,64 @@
     - SlowUnknown
     - BindUnknown
     - SleepUnknown
-# -orthodemolisher
-# -vanara
+12140-Orthoblue dragon:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - SlowUnknown
+    - SleepUnknown
+12143-Orthos vanara:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12141-Orthos Vouivre:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12137-Orthos biast:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12136-Orthokaliya:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12144-Orthoshelled dragon:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
 
 # EO boss floor 30
-# Tiamats clone
+12242-Tiamat clone:
+  Threat: Caution
+  Aggro: Undefined
+  Weakness:
 
 # EO floors 31-39
 # -mirrorknight
@@ -306,7 +359,23 @@
 # -orthospider
 # -orthikalison
 # -orthopredator
+# -orthonaga
+# -orthotaur
+# -orthoray
+# -orthochimera
+# -orthoempuse
 
 # EO boss floor 40
+# -Twintania Clone
 
 # EO floors 41-49
+# -bergthurs
+# -hedetet
+# -spriggan
+# -acheron
+# -kelpie
+# -goobbue
+# -gelato
+# -hoarhound
+# -mudman
+# -kukulkan

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -348,10 +348,10 @@
     - SleepUnknown
 
 # EO boss floor 30
-12242-Tiamat clone:
-  Threat: Caution
-  Aggro: Undefined
-  Weakness:
+# 12242-Tiamat clone:
+#   Threat: Caution
+#   Aggro: Undefined
+#   Weakness:
 
 # # EO floors 31-39
 # 12149-mirrorknight:

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -255,9 +255,8 @@
   Aggro: Sight
   Weakness:
     - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
+    - Heavy
+    - Slow
     - SleepUnknown
 12135-orthogiant:
   Threat: Easy

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -308,10 +308,9 @@
   Threat: Easy
   Aggro: Sight
   Weakness:
-    - StunUnknown
-    - HeavyUnknown
+    - Stun
     - SlowUnknown
-    - BindUnknown
+    - Slow
     - SleepUnknown
 12137-Orthos biast:
   Threat: Easy
@@ -469,16 +468,125 @@
   Aggro: Boss
 
 # EO floors 41-49
-# -bergthurs
-# -hedetet
-# -spriggan
-# -acheron
-# -kelpie
-# -goobbue
-# -gelato
-# -hoarhound
-# -mudman
-# -kukulkan
+12167-Orthos albaia:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - Heavy
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12160-Orthos bergthurs:
+  Threat: Caution
+  Aggro: Proximity
+  Weakness:
+    - StunUnknown
+    - Heavy
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12165-Orthos huwasi:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12169-Orthos hedetet:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12159-Orthos spriggan:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12166-Orthos acheron:
+  Threat: Dangerous
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12162-Orthos kelpie:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12168-Orthos goobbue:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12158-Orthos gelato:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12164-Orthos hoarhound:
+  Threat: Dangerous
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12170-Orthos mudman:
+  Threat: Easy
+  Aggro: Proximity
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12163-Orthos kukulkan:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12161-Orthos apa:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
 
 # EO boss floor 50
-# Orthochimerataw
+12265-Servomechanical chimera:
+  Threat: Caution
+  Aggro: Boss

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -294,3 +294,19 @@
     - SlowUnknown
     - BindUnknown
     - SleepUnknown
+# -orthodemolisher
+# -vanara
+
+# EO boss floor 30
+# Tiamats clone
+
+# EO floors 31-39
+# -mirrorknight
+# -orthobug
+# -orthospider
+# -orthikalison
+# -orthopredator
+
+# EO boss floor 40
+
+# EO floors 41-49

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -354,19 +354,127 @@
   Weakness:
 
 # EO floors 31-39
-# -mirrorknight
-# -orthobug
-# -orthospider
-# -orthikalison
-# -orthopredator
-# -orthonaga
-# -orthotaur
-# -orthoray
-# -orthochimera
-# -orthoempuse
+12149-mirrorknight:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12154-orthikalison:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12146-orthospider:
+  Threat: Caution
+  Aggro: Sound
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12145-orthobug:
+  Threat: Easy
+  Aggro: Proximity
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12153-Orthos shabti:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12157-Orthos lamia:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12147-orthopredator:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - SleepUnknown
+12155-orthonaga:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12150-orthotaur:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12148-Phantom orthoray:
+  Threat: Dangerous
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12151-Orthos reptoid:
+  Threat: Easy
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12152-orthochimera:
+  Threat: Dangerous
+  Aggro: Sight
+  Weakness:
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
+12156-orthoempuse:
+  Threat: Caution
+  Aggro: Sight
+  Weakness:
+    - StunUnknown
+    - HeavyUnknown
+    - SlowUnknown
+    - BindUnknown
+    - SleepUnknown
 
 # EO boss floor 40
-# -Twintania Clone
+12263-Twintania clone:
+  Threat: Caution
+  Aggro: Undefined
+  Weakness:
 
 # EO floors 41-49
 # -bergthurs

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -1,6 +1,6 @@
 # EO floors 1-9
 12108-Orthos succubus:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Sight
   Weakness:
     - Stun
@@ -8,7 +8,7 @@
     - Slow
     - SleepUnknown
 12112-Orthos imp:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Sight
   Weakness:
     - Stun
@@ -16,7 +16,7 @@
     - SlowUnknown
     - SleepUnknown
 12117-orthoiron claw:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Proximity
   Weakness:
     - Stun
@@ -24,7 +24,7 @@
     - Slow
     - SleepUnknown
 12111-Orthos dahak:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Sight
   Weakness:
     - Stun
@@ -32,7 +32,7 @@
     - SlowUnknown
     - SleepUnknown
 12110-Orthos grenade:
-  Threat: Undefined
+  Threat: Caution
   Aggro: Sight
   Weakness:
     - Stun
@@ -41,7 +41,7 @@
     - BindUnknown
     - SleepUnknown
 12115-Orthos vassago:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Sight
   Weakness:
     - HeavyUnknown
@@ -49,7 +49,7 @@
     - BindUnknown
     - SleepUnknown
 12113-Orthos demon:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Sight
   Weakness:
     - Stun
@@ -58,31 +58,31 @@
     - BindUnknown
     - SleepUnknown
 12109-Orthos behemoth:
-  Threat: Undefined
+  Threat: Caution
   Aggro: Sight
   Weakness:
     - HeavyUnknown
     - SlowUnknown
     - BindUnknown
 12106-undead Orthos dragon:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - HeavyUnknown
     - Slow
     - BindUnknown
     - Sleep
 12107-Orthos Thanatos:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - Stun
     - HeavyUnknown
     - Slow
     - BindUnknown
 12114-Orthos fachan:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -90,8 +90,8 @@
     - BindUnknown
     - Sleep
 12116-Orthos bhoot:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sound
   Weakness:
     - Stun
     - HeavyUnknown
@@ -99,7 +99,7 @@
     - BindUnknown
     - Sleep
 12118-Orthos water sprite:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Proximity
   Weakness:
     - Stun
@@ -110,7 +110,7 @@
 
 # EO boss floor 10
 12240-Gancanagh:
-  Threat: Undefined
+  Threat: Caution
   Aggro: Undefined
   Weakness:
     - StunUnknown
@@ -121,8 +121,8 @@
 
 # EO floors 11-19
 12130-great Orthos morbol:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -130,8 +130,8 @@
     - BindUnknown
     - SleepUnknown
 12129-Orthos spirulina:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -139,8 +139,8 @@
     - BindUnknown
     - SleepUnknown
 12128-Orthos netzach:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -148,8 +148,8 @@
     - BindUnknown
     - SleepUnknown
 12121-Orthos microsystem:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -157,8 +157,8 @@
     - BindUnknown
     - SleepUnknown
 12131-Orthos Belladonna:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -166,8 +166,8 @@
     - BindUnknown
     - SleepUnknown
 12123-Orthos Wood Golem:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -175,8 +175,8 @@
     - BindUnknown
     - SleepUnknown
 12122-Orthosoldier:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -184,7 +184,7 @@
     - BindUnknown
     - SleepUnknown
 12120-Orthosystem β:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Undefined
   Weakness:
     - StunUnknown
@@ -193,8 +193,8 @@
     - BindUnknown
     - SleepUnknown
 12126-Orthos Rafflesia:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -202,8 +202,8 @@
     - BindUnknown
     - SleepUnknown
 12124-Orthos Groundskeeper:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -211,8 +211,8 @@
     - BindUnknown
     - SleepUnknown
 12119-Orthohunter:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -222,7 +222,7 @@
 
 # EO boss floor 20
 12261-Cloning Node:
-  Threat: Undefined
+  Threat: Caution
   Aggro: Undefined
   Weakness:
     - StunUnknown
@@ -233,7 +233,7 @@
 
 # EO floors 21-29
 12142-Orthos brobinyak:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Sight
   Weakness:
     - StunUnknown
@@ -242,7 +242,7 @@
     - BindUnknown
     - SleepUnknown
 12132-orthodemolisher:
-  Threat: Undefined
+  Threat: Caution
   Aggro: Proximity
   Weakness:
     - StunUnknown
@@ -251,7 +251,7 @@
     - BindUnknown
     - SleepUnknown
 12139-Orthos wyvern:
-  Threat: Undefined
+  Threat: Easy
   Aggro: Sight
   Weakness:
     - StunUnknown
@@ -260,8 +260,8 @@
     - BindUnknown
     - SleepUnknown
 12135-orthogiant:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -269,7 +269,7 @@
     - BindUnknown
     - SleepUnknown
 12133-orthoknight:
-  Threat: Undefined
+  Threat: Caution
   Aggro: Sight
   Weakness:
     - StunUnknown
@@ -278,8 +278,8 @@
     - BindUnknown
     - SleepUnknown
 12134-orthodroid:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Easy
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown
@@ -287,8 +287,8 @@
     - BindUnknown
     - SleepUnknown
 12138-lesser Orthos dragon:
-  Threat: Undefined
-  Aggro: Undefined
+  Threat: Caution
+  Aggro: Sight
   Weakness:
     - StunUnknown
     - HeavyUnknown

--- a/EO/1-50.yml
+++ b/EO/1-50.yml
@@ -353,128 +353,128 @@
   Aggro: Undefined
   Weakness:
 
-# EO floors 31-39
-12149-mirrorknight:
-  Threat: Caution
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12154-orthikalison:
-  Threat: Easy
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12146-orthospider:
-  Threat: Caution
-  Aggro: Sound
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12145-orthobug:
-  Threat: Easy
-  Aggro: Proximity
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12153-Orthos shabti:
-  Threat: Easy
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12157-Orthos lamia:
-  Threat: Easy
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12147-orthopredator:
-  Threat: Easy
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - SleepUnknown
-12155-orthonaga:
-  Threat: Easy
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12150-orthotaur:
-  Threat: Caution
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12148-Phantom orthoray:
-  Threat: Dangerous
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12151-Orthos reptoid:
-  Threat: Easy
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12152-orthochimera:
-  Threat: Dangerous
-  Aggro: Sight
-  Weakness:
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
-12156-orthoempuse:
-  Threat: Caution
-  Aggro: Sight
-  Weakness:
-    - StunUnknown
-    - HeavyUnknown
-    - SlowUnknown
-    - BindUnknown
-    - SleepUnknown
+# # EO floors 31-39
+# 12149-mirrorknight:
+#   Threat: Caution
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12154-orthikalison:
+#   Threat: Easy
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12146-orthospider:
+#   Threat: Caution
+#   Aggro: Sound
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12145-orthobug:
+#   Threat: Easy
+#   Aggro: Proximity
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12153-Orthos shabti:
+#   Threat: Easy
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12157-Orthos lamia:
+#   Threat: Easy
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12147-orthopredator:
+#   Threat: Easy
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - SleepUnknown
+# 12155-orthonaga:
+#   Threat: Easy
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12150-orthotaur:
+#   Threat: Caution
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12148-Phantom orthoray:
+#   Threat: Dangerous
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12151-Orthos reptoid:
+#   Threat: Easy
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12152-orthochimera:
+#   Threat: Dangerous
+#   Aggro: Sight
+#   Weakness:
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
+# 12156-orthoempuse:
+#   Threat: Caution
+#   Aggro: Sight
+#   Weakness:
+#     - StunUnknown
+#     - HeavyUnknown
+#     - SlowUnknown
+#     - BindUnknown
+#     - SleepUnknown
 
-# EO boss floor 40
-12263-Twintania clone:
-  Threat: Caution
-  Aggro: Undefined
-  Weakness:
+# # EO boss floor 40
+# 12263-Twintania clone:
+#   Threat: Caution
+#   Aggro: Undefined
+#   Weakness:
 
 # EO floors 41-49
 # -bergthurs
@@ -487,3 +487,6 @@
 # -hoarhound
 # -mudman
 # -kukulkan
+
+# EO boss floor 50
+# Orthochimerataw

--- a/Localization/en/EO/1-50.yml
+++ b/Localization/en/EO/1-50.yml
@@ -9,10 +9,40 @@
 12133: |
   Late telegraphed draw-in into AoE
   KB immunity works
+12141: Casts roomwide vuln stacking AoE unaggroed
+12242:
+ 1) "Dark Wyrmtail" -- cleaves middle
+ 2) "Dark Wyrmwing" -- cleaves sides
+ 3) "Whei Morn" -- multiple baited AoEs
 
-# 
 
-# floor 30
-#  1) "Dark Wyrmtail" -- cleaves middle
-#  2) "Dark Wyrmwing" -- cleaves sides
-#  3) "Whei Morn" -- four baited AoEs
+# mirrorknight
+#  Casts inflicts Stun
+# orthospider
+#  PB AoE
+# orthikalison
+#  Buffs enemies with double damage
+# orthopredator
+#  Casts Haste
+# orthotaur
+#  "100 Tonze Swing" -- PB AoE
+#  "11 Tonze Swipe" -- Close Conal AoE
+# orthoray
+#  "Forearming" -- Half Circle AoE
+#  "Atmospheric Displacement" -- PB AoE
+# orthochimera
+#  "The Dragon's Voice" - doughnut
+#  "The Ram's Voice" - PB AoE
+# orthoempuse
+#  "Nothing personal kid"
+
+# floor 40
+#  1) "Twister" -- 
+
+# floor 50
+#  1) "Song of Thunder and Ice" -- doughnut then PB AoE
+#  2) "Song of Ice and Thunder" -- PB AoE then doughnut
+#  3) "Cold Thunder" -- proximity dash, PB AoE then doughnut
+#  4) "Thunderous Cold" -- proximity dash, doughnut then PB AoE
+#  5) "Leftbreathed/Rightbreathed" -- halfroom cleave
+#  6) "Cacophony" -- ball tether, kite away

--- a/Localization/en/EO/1-50.yml
+++ b/Localization/en/EO/1-50.yml
@@ -1,4 +1,11 @@
 12109: |
-  Casts Ecliptic Meteor at 40%
+  Casts Ecliptic Meteor at 40%, can LoS
+12110: Casts untelegraphed PB AoE
+12116: Casts disease
 12132: |
-  Casts Self-detonate at 30%
+  Casts Self-detonate at 30%, can LoS
+12240: |
+  Steel recommended for solo
+12133: |
+  Late telegraphed draw-in into AoE
+  KB immunity works

--- a/Localization/en/EO/1-50.yml
+++ b/Localization/en/EO/1-50.yml
@@ -10,35 +10,32 @@
   Late telegraphed draw-in into AoE
   KB immunity works
 12141: Casts roomwide vuln stacking AoE unaggroed
-12242:
+12242: |
  1) "Dark Wyrmtail" -- cleaves middle
  2) "Dark Wyrmwing" -- cleaves sides
  3) "Whei Morn" -- multiple baited AoEs
-
-
-# mirrorknight
-#  Casts inflicts Stun
-# orthospider
-#  PB AoE
-# orthikalison
-#  Buffs enemies with double damage
-# orthopredator
-#  Casts Haste
-# orthotaur
-#  "100 Tonze Swing" -- PB AoE
-#  "11 Tonze Swipe" -- Close Conal AoE
-# orthoray
-#  "Forearming" -- Half Circle AoE
-#  "Atmospheric Displacement" -- PB AoE
-# orthochimera
-#  "The Dragon's Voice" - doughnut
-#  "The Ram's Voice" - PB AoE
-# orthoempuse
-#  "Nothing personal kid"
-
-# floor 40
-#  1) "Twister" -- 
-
+12149: |
+  Casts inflicts Stun
+12146: PB AoE
+12154: |
+  Buffs enemies with double damage
+12147: Casts Haste
+12150: |
+  "100 Tonze Swing" -- PB AoE
+  "11 Tonze Swipe" -- Close Conal AoE
+12148: |
+  "Forearming" -- Half Circle AoE
+  "Atmospheric Displacement" -- PB AoE
+12152: |
+  "The Dragon's Voice" - doughnut
+  "The Ram's Voice" - PB AoE
+12156: |
+  "Nothing personal kid"
+12263: |
+  1) "Twister" -- Move away from twister bait
+  2) "Twisting Dive" -- Cleave down middle with twister bait
+  3) "Meracydian Cyclone" -- Spawns tornados with 4 baits into KB.
+    
 # floor 50
 #  1) "Song of Thunder and Ice" -- doughnut then PB AoE
 #  2) "Song of Ice and Thunder" -- PB AoE then doughnut

--- a/Localization/en/EO/1-50.yml
+++ b/Localization/en/EO/1-50.yml
@@ -9,3 +9,10 @@
 12133: |
   Late telegraphed draw-in into AoE
   KB immunity works
+
+# 
+
+# floor 30
+#  1) "Dark Wyrmtail" -- cleaves middle
+#  2) "Dark Wyrmwing" -- cleaves sides
+#  3) "Whei Morn" -- four baited AoEs

--- a/Localization/en/EO/1-50.yml
+++ b/Localization/en/EO/1-50.yml
@@ -35,11 +35,25 @@
   1) "Twister" -- Move away from twister bait
   2) "Twisting Dive" -- Cleave down middle with twister bait
   3) "Meracydian Cyclone" -- Spawns tornados with 4 baits into KB.
-    
-# floor 50
-#  1) "Song of Thunder and Ice" -- doughnut then PB AoE
-#  2) "Song of Ice and Thunder" -- PB AoE then doughnut
-#  3) "Cold Thunder" -- proximity dash, PB AoE then doughnut
-#  4) "Thunderous Cold" -- proximity dash, doughnut then PB AoE
-#  5) "Leftbreathed/Rightbreathed" -- halfroom cleave
-#  6) "Cacophony" -- ball tether, kite away
+12160: Quick behind cleave
+12169: Casts stacking slow
+12159: Casts Haste
+12166: |
+  Casts roomwide aoe, interruptable
+12162: |
+  PB AoE after dash, can LoS
+12168: |
+  Fast untelegraphed conal after suck in
+12158: |
+  Casts Explosion at 30%, can LoS
+12164: |
+  "Abyssal Cry" - Large AoE that stuns, can LoS
+12170: Applies potent heavy
+12163: Casts roomwide vuln stacking AoE unaggroed
+12265: |
+  1) "Song of Thunder and Ice" -- doughnut then PB AoE
+  2) "Song of Ice and Thunder" -- PB AoE then doughnut
+  3) "Cold Thunder" -- proximity dash, PB AoE then doughnut
+  4) "Thunderous Cold" -- proximity dash, doughnut then PB AoE
+  5) "Leftbreathed/Rightbreathed" -- halfroom cleave
+  6) "Cacophony" -- ball tether, kite away


### PR DESCRIPTION
Adds information for enemies from floor 1-50, along with aggro type and threat ratings (generally according to maygi's right side mechanical danger level). There are a few instances of tested debuffs (mostly on phys ranged), but those mainly remain untested.